### PR TITLE
Change EmailAddress' Show instance to be compatible with ByteString's and its own new Read instance.

### DIFF
--- a/src/Text/Email/Parser.hs
+++ b/src/Text/Email/Parser.hs
@@ -15,16 +15,26 @@ import Data.Char (chr)
 import Data.Attoparsec.ByteString.Char8
 import Data.Attoparsec.Combinator
 
+import qualified Text.Read as Read
+
 -- | Represents an email address.
 data EmailAddress = EmailAddress ByteString ByteString deriving (Eq,Ord)
 
 instance Show EmailAddress where
-	show = BS.unpack . toByteString
+	show = show . toByteString
+
+instance Read EmailAddress where
+	readListPrec = Read.readListPrecDefault
+	readPrec = Read.parens (do
+		bs <- Read.readPrec
+		case parseOnly addrSpec bs of
+			Left  _ -> Read.pfail
+			Right a -> return a)
 
 -- | Converts an email address back to a ByteString
 toByteString (EmailAddress l d) = BS.concat [l, BS.singleton '@', d]
 
--- | Extracts the local part of an email address. 
+-- | Extracts the local part of an email address.
 localPart :: EmailAddress -> ByteString
 localPart (EmailAddress local _) = local
 
@@ -41,13 +51,13 @@ addrSpec = do
 	return (EmailAddress localPart domainPart)
 
 local = dottedAtoms
-domain = dottedAtoms <|> domainLiteral 
+domain = dottedAtoms <|> domainLiteral
 
-dottedAtoms = BS.intercalate (BS.singleton '.') <$> 
+dottedAtoms = BS.intercalate (BS.singleton '.') <$>
 	(optional cfws *> (atom <|> quotedString) <* optional cfws)	`sepBy1` (char '.')
 atom = takeWhile1 isAtomText
 
-isAtomText x = isAlphaNum x || inClass "!#$%&'*+/=?^_`{|}~-" x 
+isAtomText x = isAlphaNum x || inClass "!#$%&'*+/=?^_`{|}~-" x
 
 domainLiteral = (BS.cons '[' . flip BS.snoc ']' . BS.concat) <$> (between (optional cfws *> char '[') (char ']' <* optional cfws) $
 	many (optional fws >> takeWhile1 isDomainText) <* optional fws)
@@ -61,7 +71,7 @@ isQuotedText x = inClass "\33\35-\91\93-\126" x || isObsNoWsCtl x
 
 quotedPair = (BS.cons '\\' . BS.singleton) <$> (char '\\' *> (vchar <|> wsp <|> lf <|> cr <|> obsNoWsCtl <|> nullChar))
 
-cfws = ignore $ many (comment <|> fws) 
+cfws = ignore $ many (comment <|> fws)
 
 fws :: Parser ()
 fws = ignore $

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -18,12 +18,16 @@ main = defaultMain tests
 
 tests :: [TF.Test]
 tests = [
+        testGroup "EmailAddress Show/Read instances" [
+                testProperty "showLikeByteString" prop_showLikeByteString,
+                testProperty "showAndReadBack" prop_showAndReadBack
+                ],
         testGroup "QuickCheck Text.Email.Validate" [
                 testProperty "doubleCanonicalize" prop_doubleCanonicalize
                 ],
-        testGroup "Unit tests Text.Email.Validate" $ flip concatMap units 
+        testGroup "Unit tests Text.Email.Validate" $ flip concatMap units
             (\(em, valid, why) -> let email = BS.pack em
-                in 
+                in
                     [
                     testCase ("doubleCanonicalize '" ++ em ++ "'") (True @=? case emailAddress email of { Nothing -> True; Just ok -> prop_doubleCanonicalize ok }),
                     testCase ("validity test '" ++ em ++ "'") (valid @=? isValid email)
@@ -46,6 +50,12 @@ isEmail l d = isValid (makeEmailLike l d)
 makeEmailLike l d = BS.concat [l, BS.singleton '@', d]
 
 prop_doubleCanonicalize email =  Just email == emailAddress (toByteString email)
+
+prop_showLikeByteString :: EmailAddress -> Bool
+prop_showLikeByteString email = show (toByteString email) == show email
+
+prop_showAndReadBack :: EmailAddress -> Bool
+prop_showAndReadBack email = read (show email) == email
 
 --unitTest (x, y, z) = if not (isValid (BS.pack x) == y) then "" else (x ++" became "++ (case emailAddress (BS.pack x) of {Nothing -> "fail"; Just em -> show em}) ++": Should be "++show y ++", got "++show (not y)++"\n\t"++z++"\n")
 


### PR DESCRIPTION
Currently, the `Show` instance for `EmailAddress` works as follows:

``` haskell
>>> show (fromJust $ Text.Email.Validate.emailAddress "foo@bar.com")
"foo@bar.com"
```

Whereas trying to `show` the underlying `ByteString` yields a different result:

``` haskell
>>> show ("foo@bar.com" :: ByteString)
"\"foo@bar.com\""
```

In this pull-request I propose a **backwards incompatible** change: that the `EmailAddress`'s `Show` instance behaves like that of `ByteString` (and `String` and `Text`), which renders as a valid Haskell expression. 

The main reason why I'm interested in this change is not the behavior of `Show` itself, but instead, I'm interested in adding a `Read` instance for `EmailAddress` compatible with `Show` (that is, `read . show = id`). Automatically derived `Show` and `Read` instances have this behavior. However, given that email addresses can contain whitespace and other _funny_ characters like `(` a `)`, I doubt it is possible to do so unless the email address is well-delimited (as it is in the case of `ByteString`'s `Read` instance for example, where `"` is used as a delimiter).

So, given that `Read` and `Show` are quite handy when doing basic serialization and deserialization routines, and that `EmailAddress` is frequently used as part of a larger structure (say, the contact details for a client) that could otherwise be `show`n and `read` back: Could we ease this serialization and deserialization routines by providing these two new instances by default?

In this pull-request I provide an implementation and some tests.
