### PR TITLE
Add ghc-prim package to dependencies and bump version to 2.0.1

### DIFF
--- a/email-validate.cabal
+++ b/email-validate.cabal
@@ -1,5 +1,5 @@
 name:           email-validate
-version:        2.0.0
+version:        2.0.1
 license:        BSD3
 license-file:   LICENSE
 author:         George Pollard <porges@porg.es>
@@ -25,6 +25,7 @@ library
     build-depends: base >= 4 && < 5
                  , attoparsec >= 0.10.0
                  , bytestring >= 0.9
+                 , ghc-prim
     ghc-options: -O2
     hs-source-dirs: src
     exposed-modules: Text.Email.Validate


### PR DESCRIPTION
If the ghc-prim package is not there it complains with a

src/Text/Email/Parser.hs:22:8:
    Could not find module `GHC.Generics'
    It is a member of the hidden package`ghc-prim'.
    Perhaps you need to add `ghc-prim' to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
