### PR TITLE
Bump doctest upper bound to <0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,5 @@ script: stack $ARGS --no-terminal --install-ghc test --haddock
 cache:
   directories:
   - $HOME/.stack
+  - $HOME/.ghc
+  - $HOME/.cabal

--- a/email-validate.cabal
+++ b/email-validate.cabal
@@ -1,5 +1,5 @@
 name:           email-validate
-version:        2.3.1
+version:        2.3.2
 license:        BSD3
 license-file:   LICENSE
 author:         George Pollard <porges@porg.es>
@@ -19,7 +19,7 @@ source-repository head
 source-repository this
     type: git
     location: git://github.com/Porges/email-validate-hs.git
-    tag: v2.3.1
+    tag: v2.3.2
 
 library
     build-depends:
@@ -56,5 +56,5 @@ test-suite doctests
     main-is: doctests.hs
     build-depends:
         base >= 4 && < 5,
-        doctest >= 0.8 && < 0.13
+        doctest >= 0.8 && < 0.14
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ extra-package-dbs: []
 packages:
 - '.'
 extra-deps: []
-resolver: lts-9.0
+resolver: lts-9.12


### PR DESCRIPTION
This allows use of latest `doctest` on Hackage.