### PR TITLE
Relax constraint, allow template-haskell-2.14.*

### DIFF
--- a/email-validate.cabal
+++ b/email-validate.cabal
@@ -26,7 +26,7 @@ library
         base >= 4.4 && < 5,
         attoparsec >= 0.10.0 && < 0.14,
         bytestring >= 0.9 && < 0.11,
-        template-haskell >= 2.10.0.0 && < 2.14
+        template-haskell >= 2.10.0.0 && < 2.15
     default-language: Haskell2010
     hs-source-dirs: src
     ghc-options: -Wall


### PR DESCRIPTION
I believe this is the only change necessary to get this package working with ghc 8.6 and back into Stackage nightly builds.

Tested successfully with the following stack.yaml:

```yaml
flags: {}
extra-package-dbs: []
packages:
- '.'
extra-deps: []
resolver: nightly-2018-10-09
```