### PR TITLE
Use CaseInsensitive for domain part to follow RFC

### DIFF
--- a/email-validate.cabal
+++ b/email-validate.cabal
@@ -26,7 +26,8 @@ library
         base >= 4.4 && < 5,
         attoparsec >= 0.10.0 && < 0.14,
         bytestring >= 0.9 && < 0.11,
-        template-haskell >= 2.10.0.0 && < 2.16
+        template-haskell >= 2.10.0.0 && < 2.16,
+        case-insensitive >= 1.2.0.11 && < 1.3
     default-language: Haskell2010
     hs-source-dirs: src
     ghc-options: -Wall

--- a/src/Text/Email/Parser.hs
+++ b/src/Text/Email/Parser.hs
@@ -4,6 +4,7 @@ module Text.Email.Parser
     ( addrSpec
     , localPart
     , domainPart
+    , domainPartOriginal
     , EmailAddress
     , unsafeEmailAddress
     , toByteString
@@ -15,12 +16,13 @@ import           Control.Monad (guard, void, when)
 import           Data.Attoparsec.ByteString.Char8
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.CaseInsensitive as CI
 import           Data.Data (Data, Typeable)
 import           GHC.Generics (Generic)
 import qualified Text.Read as Read
 
 -- | Represents an email address.
-data EmailAddress = EmailAddress ByteString ByteString
+data EmailAddress = EmailAddress ByteString (CI.CI ByteString)
     deriving (Eq, Ord, Data, Typeable, Generic)
 
 -- | Creates an email address without validating it.
@@ -28,7 +30,7 @@ data EmailAddress = EmailAddress ByteString ByteString
 --   somewhere it has already been validated (e.g. a
 --   database).
 unsafeEmailAddress :: ByteString -> ByteString -> EmailAddress
-unsafeEmailAddress = EmailAddress
+unsafeEmailAddress lp = EmailAddress lp . CI.mk
 
 instance Show EmailAddress where
     show = show . toByteString
@@ -43,7 +45,7 @@ instance Read EmailAddress where
 
 -- | Converts an email address back to a ByteString
 toByteString :: EmailAddress -> ByteString
-toByteString (EmailAddress l d) = BS.concat [l, BS.singleton '@', d]
+toByteString (EmailAddress l d) = BS.concat [l, BS.singleton '@', CI.foldedCase d]
 
 -- | Extracts the local part of an email address.
 localPart :: EmailAddress -> ByteString
@@ -51,7 +53,12 @@ localPart (EmailAddress l _) = l
 
 -- | Extracts the domain part of an email address.
 domainPart :: EmailAddress -> ByteString
-domainPart (EmailAddress _ d) = d
+domainPart (EmailAddress _ d) = CI.foldedCase d
+
+-- | Extracts the domain part of an email address in its original case
+domainPartOriginal :: EmailAddress -> ByteString
+domainPartOriginal (EmailAddress _ d) = CI.original d
+
 
 -- | A parser for email addresses.
 addrSpec :: Parser EmailAddress

--- a/src/Text/Email/Parser.hs
+++ b/src/Text/Email/Parser.hs
@@ -22,7 +22,7 @@ import           GHC.Generics (Generic)
 import qualified Text.Read as Read
 
 -- | Represents an email address.
-data EmailAddress = EmailAddress ByteString (CI.CI ByteString)
+data EmailAddress = EmailAddress (CI.CI ByteString) (CI.CI ByteString)
     deriving (Eq, Ord, Data, Typeable, Generic)
 
 -- | Creates an email address without validating it.
@@ -30,7 +30,7 @@ data EmailAddress = EmailAddress ByteString (CI.CI ByteString)
 --   somewhere it has already been validated (e.g. a
 --   database).
 unsafeEmailAddress :: ByteString -> ByteString -> EmailAddress
-unsafeEmailAddress lp = EmailAddress lp . CI.mk
+unsafeEmailAddress lp dp = EmailAddress ( CI.mk lp ) ( CI.mk dp )
 
 instance Show EmailAddress where
     show = show . toByteString
@@ -45,11 +45,11 @@ instance Read EmailAddress where
 
 -- | Converts an email address back to a ByteString
 toByteString :: EmailAddress -> ByteString
-toByteString (EmailAddress l d) = BS.concat [l, BS.singleton '@', CI.foldedCase d]
+toByteString (EmailAddress l d) = BS.concat [CI.foldedCase l, BS.singleton '@', CI.foldedCase d]
 
 -- | Extracts the local part of an email address.
 localPart :: EmailAddress -> ByteString
-localPart (EmailAddress l _) = l
+localPart (EmailAddress l _) = CI.foldedCase l
 
 -- | Extracts the domain part of an email address.
 domainPart :: EmailAddress -> ByteString


### PR DESCRIPTION
According to RFC 1035, section 3.1:
> Name servers and resolvers must compare [domains] in a case-insensitive manner

So I believe the `Eq` and `Ord` instances of `EmailAddress` should take it into account. This PR implements it in a API preserving way which didn't need tweaking any tests by using `Data.CaseInsensitive.CI` to store the domain part- A `domainPartOriginal` is provided to extract it in the original case in which it was parsed. Perhaps, fort better backwards compatibility, it should be the other way around? (ie: provide a `domainPartFoldedCase` to extract it folded and leave `domainPart` returning the original case)