### PR TITLE
Introduce a failing test for dotless domain

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -161,6 +161,7 @@ examples =
     let domain249 = BS.intercalate "." (take 25 (repeat (BS.replicate 9 'x'))) in
     [ valid "first.last@example.com"
     , valid "first.last@example.com." `why` "Dot allowed on end of domain"
+    , invalid "first.last@examplecom" `why` "Domain part does not contain a dot, per ICANN https://www.icann.org/news/announcement-2013-08-30-en"
     , invalid "local@exam_ple.com" `why` "Underscore not permitted in domain"
     , valid "1234567890123456789012345678901234567890123456789012345678901234@example.com"
     , valid "\"first last\"@example.com" `why` "Contains quoted spaces"


### PR DESCRIPTION
## Source Issue

https://github.com/Porges/email-validate-hs/issues/52

## Issue

ICANN has prohibited dotless domain names:

https://www.icann.org/news/announcement-2013-08-30-en

While these are technically possible in the spec, they have effectively
been made invalid. email-validate will accept these domains in its
current form, when it should mark them as invalid.

## Description

This PR introduces a failing test.