### PR TITLE
Allow template-haskell-2.19 (GHC 9.4)

### DIFF
--- a/email-validate.cabal
+++ b/email-validate.cabal
@@ -26,7 +26,7 @@ library
         base >= 4.4 && < 5,
         attoparsec >= 0.10.0 && < 0.15,
         bytestring >= 0.9 && < 0.12,
-        template-haskell >= 2.10.0.0 && < 2.19
+        template-haskell >= 2.10.0.0 && < 2.20
     default-language: Haskell2010
     hs-source-dirs: src
     ghc-options: -Wall


### PR DESCRIPTION
Tested:

* On GHC-9.4.3/Cabal-3.8.1.0/doctest-0.20.1
* On GHC-8.10.7/Cabal-3.6.2.0/doctest-0.20.1

using the following command:

    cabal repl --with-ghc=doctest --ghc-options="-XQuasiQuotes -XOverloadedStrings"

Keep in mind that doctest needs to be rebuilt when switching GHC version.

The existing doctest build setup doesn't work for me, not even on GHC 8.6 with
a really old doctest version. It should be removed. The `with-ghc` method of invoking
doctest is nice because it doesn't rely on environment files.

The unit tests also pass.
